### PR TITLE
Ошибка в каррировании

### DIFF
--- a/karatsuba.md
+++ b/karatsuba.md
@@ -32,8 +32,8 @@ void carry(int *a, int n) {
     int d = 0;
     for (int i = 0; i < n; i++) {
         a[i] += d;
-        d = a[i] % base;
-        a[i] /= base;
+        d = a[i] / base;
+        a[i] %= base;
     }
 }
 ```


### PR DESCRIPTION
В разряде должен оставаться как раз остаток от деления на основание, а вот уже всё остальное переносится на следующий.